### PR TITLE
add Nummy::Enum.to_attribute for integration with ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,55 @@ end
 > [!TIP]
 > `Nummy::Enum` extends `Enumerable` and iterates over the _values_ of the enum, so you have access to things like `.include?(value)`, `.any?`, and `.find`.
 
+#### Rails / ActiveRecord integration
+
+> [!IMPORTANT]
+> This integration requires `ActiveSupport::Inflector` to be defined.
+
+To use nummy enums as ActiveRecord enums, you can use the `.to_attribute` method:
+
+```ruby
+class Conversation < ActiveRecord::Base
+  class Status < Nummy::Enum
+    ACTIVE = auto
+    ARCHIVED = auto
+  end
+
+  enum :status, Status.to_attribute
+end
+```
+
+This allows you to use all of the Rails magic for enums, like scopes and boolean helpers, while also being able to refer to values in a safer way than hash lookups.
+
+That is, these two are the same:
+
+```ruby
+Conversation.statuses[:active] # => 0
+Conversation::Status::ACTIVE   # => 0
+```
+
+But these are not:
+
+```ruby
+Conversation.statuses[:acitve]
+# => nil
+
+Conversation::Status::ACITVE   # => nil
+# =>
+#  uninitialized constant Conversation::Status::ACITVE (NameError)
+#  Did you mean?  Conversation::Status::ACTIVE
+```
+
+You can get similar behavior using `#fetch`:
+
+```ruby
+Conversation.statuses.fetch(:acitve)
+# => key not found: :acitve (KeyError)
+#    Did you mean?  :active
+```
+
+But that still misses out on some of the DX benefits of using constants, like improved support for things like autocompletion, documentation, and navigation ("Go To Definition") in editors.
+
 ### `Nummy::MemberEnumerable`
 
 `Nummy::MemberEnumerable` is a module that includes `Enumerable` and makes it possible to iterate over any class or module that responds to `members`.

--- a/lib/nummy/enum.rb
+++ b/lib/nummy/enum.rb
@@ -354,6 +354,32 @@ module Nummy
       # Alias to support splatting enums into keyword args.
       alias to_hash to_h
 
+      # Converts the enum to a +Hash+ with snake_case keys.
+      #
+      # This is intended to be used with +ActiveRecord::Enum+, but can be used
+      # with any library that supports defining enums using a +Hash+ and expects
+      # to have lowercase keys.
+      #
+      # @note
+      #   This method _equires +ActiveSupport::Inflector+ to be defined.
+      #
+      # @return [Hash{Symbol => Integer}]
+      #
+      # @example
+      #   class Conversation < ActiveRecord::Base
+      #     class Status < Nummy::Enum
+      #       ACTIVE = auto
+      #       ARCHIVED = auto
+      #     end
+      #
+      #     enum :status, Status.to_attribute
+      #   end
+      def to_attribute
+        to_h.transform_keys! do |key|
+          ::ActiveSupport::Inflector.underscore(key).to_sym
+        end
+      end
+
       # Returns a string representation of +self+.
       #
       # The string will contain the name-value pairs of the constants in +self+.

--- a/test/nummy/enum/to_attribute_test.rb
+++ b/test/nummy/enum/to_attribute_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Nummy::Enum do
+  describe ".to_attribute" do
+    it "returns a hash containing the snake_cased key-value pairs of the enum" do
+      require "active_support/inflector"
+
+      subject =
+        Class.new(Nummy::Enum) do |enum|
+          # Disable naming conventions so that we can test that we're using
+          # the inflector, and not just .downcase or a simple regex.
+          # rubocop:disable Naming/ConstantName
+
+          enum::SHOUTY_CASE = 0
+          enum::PascalCase = 1
+          enum::Mixed_Case = 2
+          enum::ABBRCase = 3 # acronyms & abbreviations
+
+          # rubocop:enable Naming/ConstantName
+        end
+
+      expected = { shouty_case: 0, pascal_case: 1, mixed_case: 2, abbr_case: 3 }
+
+      assert_equal expected, subject.to_attribute
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a method to convert a Nummy::Enum to a hash that's in the shape expected by ActiveRecord::Enum.