### PR TITLE
Teach `Nummy::Enum.to_attribute` new tricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,7 @@ end
 
 #### Rails / ActiveRecord integration
 
-> [!IMPORTANT]
-> This integration requires `ActiveSupport::Inflector` to be defined.
-
-To use nummy enums as ActiveRecord enums, you can use the `.to_attribute` method:
+To use nummy enums as ActiveRecord enums, you can use the `.to_attribute` method, which converts the keys to `snake_case` by default:
 
 ```ruby
 class Conversation < ActiveRecord::Base
@@ -164,7 +161,13 @@ class Conversation < ActiveRecord::Base
 end
 ```
 
-This allows you to use all of the Rails magic for enums, like scopes and boolean helpers, while also being able to refer to values in a safer way than hash lookups.
+> [!NOTE]
+> `to_attribute` will transform keys using `String#underscore` if it is defined, otherwise it will use `Symbol#downcase`.
+
+> [!TIP]
+> You can also do custom transformations by passing a block to `to_attribute`. See the documentation for more details.
+
+Using `to_attribute` allows you to use all of the Rails magic for enums, like scopes and boolean helpers, while also being able to refer to values in a safer way than hash lookups.
 
 That is, these two are the same:
 

--- a/test/nummy/enum/to_attribute_test.rb
+++ b/test/nummy/enum/to_attribute_test.rb
@@ -4,26 +4,67 @@ require "test_helper"
 
 describe Nummy::Enum do
   describe ".to_attribute" do
-    it "returns a hash containing the snake_cased key-value pairs of the enum" do
-      require "active_support/inflector"
+    subject do
+      Class.new(Nummy::Enum) do |enum|
+        # Disable naming conventions so that we can test that we're using
+        # the inflector, and not just .downcase or a simple regex.
+        # rubocop:disable Naming/ConstantName
 
-      subject =
-        Class.new(Nummy::Enum) do |enum|
-          # Disable naming conventions so that we can test that we're using
-          # the inflector, and not just .downcase or a simple regex.
-          # rubocop:disable Naming/ConstantName
+        enum::SCREAMING_SNAKE_CASE= 0
+        enum::UpperCamelCase = 1
+        enum::Mixed_Case = 2
+        enum::ABBRCase = 3 # acronyms & abbreviations
 
-          enum::SHOUTY_CASE = 0
-          enum::PascalCase = 1
-          enum::Mixed_Case = 2
-          enum::ABBRCase = 3 # acronyms & abbreviations
+        # rubocop:enable Naming/ConstantName
+      end
+    end
 
-          # rubocop:enable Naming/ConstantName
+    describe "when no block is given" do
+      describe "when String#underscore is defined" do
+        it "transforms keys using String#underscore" do
+          actual =
+            ForkedProc.call do
+              # Avoid loading ActiveSupport into the main test process
+              require "active_support/core_ext/string/inflections"
+              subject.to_attribute
+            end
+
+          expected = {
+            screaming_snake_case: 0,
+            upper_camel_case: 1,
+            mixed_case: 2,
+            abbr_case: 3
+          }
+
+          assert_equal expected, actual
         end
+      end
 
-      expected = { shouty_case: 0, pascal_case: 1, mixed_case: 2, abbr_case: 3 }
+      describe "when String#underscore is NOT defined" do
+        it "transforms keys using Symbol#downcase" do
+          expected = {
+            screaming_snake_case: 0,
+            uppercamelcase: 1,
+            mixed_case: 2,
+            abbrcase: 3
+          }
 
-      assert_equal expected, subject.to_attribute
+          assert_equal expected, subject.to_attribute
+        end
+      end
+    end
+
+    describe "when a block is given" do
+      it "transforms the keys with the given block" do
+        expected = {
+          SCREAMING_SNAKE_CASE: 0,
+          UPPERCAMELCASE: 1,
+          MIXED_CASE: 2,
+          ABBRCASE: 3
+        }
+
+        assert_equal expected, subject.to_attribute(&:upcase)
+      end
     end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "support/utils/forked_proc"

--- a/test/support/utils/forked_proc.rb
+++ b/test/support/utils/forked_proc.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "English"
+
+# Helper for executing test code in a forked process.
+#
+# This can be used to test code that relies on gems like ActiveSupport that
+# pollute the global namespace.
+class ForkedProc
+  # Executes the given block in a forked process and returns the block result.
+  #
+  # Raises an exception if the block raises an exception.
+  def self.call(&)
+    new.call(&)
+  end
+
+  private_class_method :new
+
+  attr_reader :reader
+  attr_reader :writer
+
+  def initialize
+    @reader, @writer = IO.pipe
+  end
+
+  def call(&)
+    pid = fork_call(&)
+
+    writer.close
+    result = reader.read
+    Process.wait(pid)
+
+    # We're only marshalling our own objects, so this is safe enough.
+    # rubocop:disable Security/MarshalLoad
+    Marshal.load(result).tap { |r| raise r if r.is_a?(::Exception) }
+    # rubocop:enable Security/MarshalLoad
+  end
+
+  def fork_call(&)
+    Process.fork do
+      reader.close
+
+      result =
+        begin
+          yield
+        rescue StandardError
+          $ERROR_INFO
+        end
+
+      Marshal.dump(result, writer)
+
+      # skip exit hooks so that we don't accidentally end the test suite
+      Process.exit!(true)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,5 +7,6 @@ require "initializers/minitest"
 
 require "support/assertions"
 require "support/fixtures"
+require "support/utils"
 
 require "nummy"


### PR DESCRIPTION
This PR makes `Nummy::Enum.to_attribute` more flexible in three ways:

- it allows passing a block to fully customize how keys are transformed

- it looks for `String#underscore` rather than calling into   `ActiveSupport::Inflector.underscore` directly, which means that users can bring their own monkey patch if they want to.

- it falls back to `Symbol#downcase` if `String#underscore` is not available. If the constants are defined using SCREAMING_SNAKE_CASE, this will generally have the same result as calling `String#underscore`, but without requiring ActiveSupport.