### PR TITLE
add JSON support to Nummy::Enum

### DIFF
--- a/lib/nummy/enum.rb
+++ b/lib/nummy/enum.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 require "nummy/auto_sequenceable"
 require "nummy/ordered_const_enumerable"
 require "nummy/errors"
@@ -353,6 +355,26 @@ module Nummy
 
       # Alias to support splatting enums into keyword args.
       alias to_hash to_h
+
+      # Converts +self+ to a +Hash+ that can be converted to JSON.
+      #
+      # @return [Hash{String => Object}]
+      #
+      # @see .to_json
+      def as_json
+        to_h.transform_keys!(&:to_s)
+      end
+
+      # Converts +self+ to a +Hash+ and serializes it to  a JSON string.
+      #
+      # Supports same options as +JSON#generate+.
+      #
+      # @return [String]
+      #
+      # @see .as_json
+      def to_json(*)
+        as_json.to_json(*)
+      end
 
       # Converts the enum to a +Hash+ with snake_case keys.
       #

--- a/test/nummy/enum/as_json_test.rb
+++ b/test/nummy/enum/as_json_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Nummy::Enum do
+  describe ".as_json" do
+    it "returns a hash containing the key-value pairs of the enum" do
+      subject = Fixtures::Enum::CardinalDirection
+
+      expected = { "NORTH" => 0, "EAST" => 90, "SOUTH" => 180, "WEST" => 270 }
+
+      assert_equal expected, subject.as_json
+    end
+
+    it "returns an empty hash when the enum is empty" do
+      subject = Fixtures::Enum::Empty
+
+      assert_empty subject.as_json
+    end
+  end
+end

--- a/test/nummy/enum/to_json_test.rb
+++ b/test/nummy/enum/to_json_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Nummy::Enum do
+  describe ".to_json" do
+    it "returns a hash containing the key-value pairs of the enum" do
+      subject = Fixtures::Enum::CardinalDirection
+
+      expected = {
+        "NORTH" => 0,
+        "EAST" => 90,
+        "SOUTH" => 180,
+        "WEST" => 270
+      }
+
+      assert_equal expected.to_json, subject.to_json
+    end
+
+    it "returns an empty hash when the enum is empty" do
+      subject = Fixtures::Enum::Empty
+
+      assert_equal "{}", subject.to_json
+    end
+  end
+end


### PR DESCRIPTION
This commit adds `.as_json` and `.to_json` methods to `Nummy::Enum`. These methods allow the enums to be serialized to JSON.