### PR TITLE
pin ruby/setup-ruby to 3.2 in push_gem.yml

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          # not using ruby 3.3 because of this issue:
+          # https://github.com/rubygems/release-gem/issues/2
+          ruby-version: '3.2'
           bundler-cache: true
-          ruby-version: ruby
 
       # Release
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
This hopefully resolves an issue where the push_gem workflow succesfully pushes the gem to RubyGems.org, but fails to complete the full workflow successfully.

See https://github.com/rubygems/release-gem/issues/2 for more information.